### PR TITLE
Wordpress encodes & in title and content section

### DIFF
--- a/revisionize.php
+++ b/revisionize.php
@@ -179,6 +179,8 @@ function copy_post($post, $to=null, $parent_id=null, $status='draft') {
     'post_date_gmt' => get_gmt_from_date($post->post_date)
   );
 
+  kses_remove_filters();
+
   if ($to) {
     $data['ID'] = $to->ID;
     $new_id = $to->ID;
@@ -190,7 +192,9 @@ function copy_post($post, $to=null, $parent_id=null, $status='draft') {
 
   copy_post_taxonomies($new_id, $post);
   copy_post_meta_info($new_id, $post);
-  
+
+  kses_init_filters();
+
   return $new_id;
 }
 


### PR DESCRIPTION
Hi,

we currently have a problem with revisionize. When a revision is schedule via wordpress and is published via wp-cron the title and content might get filtered by wordpress KSE filters.

For example when a post has a title in the revision:

> This is a test & it should work

and you schedule it. it gets published and the converted to:

> This is a test &amp; it should work 

so the ampersands are converted to htmlenties. This is only happening if the post was scheduled and then published via wordpress cron. Important note: we disabled WP-Cron and calling it with curl through a cron entry on our server. So when the post gets published **wp_update_post** and **wp_insert_post** use extra KSE filter rules to filter this entities.

If the post is normally published by pressing the publish button everything works as expected.

I therefor would like to propose to disabled KSE filters during post publish and update when a revision goes live and then reinitiate the KSE filters. (see PR)

Please note in the PR is no check if the script is currently executed in the WP-Cron context. It might be better to test for it.

Also I tested it only with posts but did not test it with pages or taxonomies.

Thanks,

Alex