### PR TITLE
Adds a filter to customise 'Revisionize' button text

### DIFF
--- a/revisionize.php
+++ b/revisionize.php
@@ -258,7 +258,7 @@ function post_button() {
   if (!$parent): ?>
     <div style="text-align: right; margin-bottom: 10px;">
       <a class="button"
-        href="<?php echo get_create_link($post) ?>"><?php _e('Revisionize', REVISIONIZE_I18N_DOMAIN); ?>
+        href="<?php echo get_create_link($post) ?>"><?php echo apply_filters('revisionize_create_revision_button_text', __('Revisionize', REVISIONIZE_I18N_DOMAIN)); ?>
       </a>
     </div>
   <?php else: ?>
@@ -271,7 +271,7 @@ function admin_actions($actions, $post) {
   if (is_create_enabled($post)) {
     $actions['create_revision'] = '<a href="'.get_create_link($post).'" title="'
       . esc_attr(__("Create a Revision", REVISIONIZE_I18N_DOMAIN))
-      . '">' .  __('Revisionize', REVISIONIZE_I18N_DOMAIN) . '</a>';
+      . '">' .  apply_filters('revisionize_create_revision_button_text', __('Revisionize', REVISIONIZE_I18N_DOMAIN)) . '</a>';
   }
   return $actions;
 }


### PR DESCRIPTION
Firstly, thanks for creating this plugin. It works really well.

However not all users will know what a button that says 'Revisionize' means. This PR will allow developers to customise the button text using a filter

***

The filter 'revisionize_create_revision_button_text' has been added to allow users to customise the 'Revisionize' button text.

To customise the button text, in your theme's functions.php put the following:

```
add_filter('revisionize_create_revision_button_text', function ($button_text) {
    return 'Your text here';
});
```