### PR TITLE
Adds a dashboard widget showing pending revisions

### DIFF
--- a/revisionize.php
+++ b/revisionize.php
@@ -308,41 +308,41 @@ function notice() {
 
 // Add a dashboard widget showing posts needing review
 function add_dashboard_widget() {
-    wp_add_dashboard_widget(
-        'revisionize-posts-needing-review',    // ID of the widget.
-        'Posts needing review',                // Title of the widget.
-        __NAMESPACE__.'\\do_dashboard_widget'  // Callback.
-    );
+  wp_add_dashboard_widget(
+    'revisionize-posts-needing-review',    // ID of the widget.
+    'Posts needing review',                // Title of the widget.
+    __NAMESPACE__.'\\do_dashboard_widget'  // Callback.
+  );
 }
 
 // Echo the content of the dashboard widget.
 function do_dashboard_widget() {
-    $posts = get_posts( array(
-        'post_type'   => 'any',
-        'post_status' => 'pending',
-        'meta_query'  => array(
-            array(
-                'key'     => '_post_revision',
-                'compare' => 'EXISTS',
-                )
-            )
-        ) );
+  $posts = get_posts( array(
+    'post_type'   => 'any',
+    'post_status' => 'pending',
+    'meta_query'  => array(
+      array(
+        'key'     => '_post_revision',
+        'compare' => 'EXISTS',
+        )
+      )
+    ) );
 
-    if ( empty( $posts ) ) {
-        _e( 'No posts need reviewed at this time!', 'revisionize' );
-    }
+  if ( empty( $posts ) ) {
+    _e( 'No posts need reviewed at this time!', 'revisionize' );
+  }
 
-    echo '<ul>';
+  echo '<ul>';
 
-    foreach ( $posts as $post ) {
-        printf( '<li><a href="%s">%s</a> - %s</li>',
-            get_edit_post_link( $post->ID ),
-            get_the_title( $post->ID ),
-            get_the_author_meta( 'nicename', $post->post_author )
-            );
-    }
+  foreach ( $posts as $post ) {
+    printf( '<li><a href="%s">%s</a> - %s</li>',
+      get_edit_post_link( $post->ID ),
+      get_the_title( $post->ID ),
+      get_the_author_meta( 'nicename', $post->post_author )
+      );
+  }
 
-    echo '</ul>';
+  echo '</ul>';
 }
 
 // -- Helpers

--- a/revisionize.php
+++ b/revisionize.php
@@ -44,7 +44,10 @@ function init() {
     add_action('admin_notices', __NAMESPACE__.'\\notice');
 
     add_action('before_delete_post', __NAMESPACE__.'\\on_delete_post');
+  }
 
+  // For users who can publish.
+  if ( is_admin() && user_can_publish_revision() ) {
     add_action( 'wp_dashboard_setup', __NAMESPACE__.'\\add_dashboard_widget' );
   }
 
@@ -305,10 +308,6 @@ function notice() {
 
 // Add a dashboard widget showing posts needing review
 function add_dashboard_widget() {
-    if ( ! user_can_publish_revision() ) {
-        return;
-    }
-
     wp_add_dashboard_widget(
         'revisionize-posts-needing-review',    // ID of the widget.
         'Posts needing review',                // Title of the widget.


### PR DESCRIPTION
This PR adds a dashboard widget that shows all posts submitted for revision.

_User Story:_ As a content editor of a WordPress site, I would like an easy way to see all posts that users have edited and submitted for revision. Rather than checking every post type and looking for posts that are marked as `Pending`, a single place to look would simplify my workflow.

_Implementation:_ Adds a widget to the WP dashboard homepage that shows a list of posts (any type) that are currently submitted for review. Max of 10 at a time. Only shows to users who can publish a revision.

Also cleans up all trailing whitespace.

