### PR TITLE
Update revisionize.php

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -37,6 +37,7 @@ Please post in the support section for help before leaving a negative review!
 = 1.3.2 =
 * Maintain original post dates when a revision is published
 * Add filter (revisionize_keep_original_on_publish) to override behaviour of keeping the original as a revision when publishing. 
+* Hide experimental dashboard widget that was added in 1.3.0. [See here](https://github.com/jamiechong/revisionize/pull/7) if you want to show this widget again.
 
 = 1.3.1 =
 * Fix issue where publishing a revision did not overwrite the original post when ACF 5 was installed but no fields were assigned to the post type.

--- a/readme.txt
+++ b/readme.txt
@@ -34,6 +34,10 @@ Please post in the support section for help before leaving a negative review!
 
 == Changelog ==
 
+= 1.3.2 =
+* Maintain original post dates when a revision is published
+* Add filter (revisionize_keep_original_on_publish) to override behaviour of keeping the original as a revision when publishing. 
+
 = 1.3.1 =
 * Fix issue where publishing a revision did not overwrite the original post when ACF 5 was installed but no fields were assigned to the post type.
 

--- a/revisionize.php
+++ b/revisionize.php
@@ -47,8 +47,8 @@ function init() {
   }
 
   // For users who can publish.
-  if ( is_admin() && user_can_publish_revision() ) {
-    add_action( 'wp_dashboard_setup', __NAMESPACE__.'\\add_dashboard_widget' );
+  if (show_dashboard_widget() && is_admin() && user_can_publish_revision()) {
+    add_action('wp_dashboard_setup', __NAMESPACE__.'\\add_dashboard_widget');
   }
 
   // For Cron and users who can publish
@@ -324,14 +324,14 @@ function notice() {
 function add_dashboard_widget() {
   wp_add_dashboard_widget(
     'revisionize-posts-needing-review',    // ID of the widget.
-    'Posts needing review',                // Title of the widget.
+    __('Revisionized Posts Needing Review'),                // Title of the widget.
     __NAMESPACE__.'\\do_dashboard_widget'  // Callback.
   );
 }
 
 // Echo the content of the dashboard widget.
 function do_dashboard_widget() {
-  $posts = get_posts( array(
+  $posts = get_posts(array(
     'post_type'   => 'any',
     'post_status' => 'pending',
     'meta_query'  => array(
@@ -340,20 +340,20 @@ function do_dashboard_widget() {
         'compare' => 'EXISTS',
         )
       )
-    ) );
+    ));
 
-  if ( empty( $posts ) ) {
-    _e( 'No posts need reviewed at this time!', 'revisionize' );
+  if (empty($posts)) {
+    _e('No posts need reviewed at this time!', 'revisionize');
   }
 
   echo '<ul>';
 
-  foreach ( $posts as $post ) {
-    printf( '<li><a href="%s">%s</a> - %s</li>',
-      get_edit_post_link( $post->ID ),
-      get_the_title( $post->ID ),
-      get_the_author_meta( 'nicename', $post->post_author )
-      );
+  foreach ($posts as $post) {
+    printf('<li><a href="%s">%s</a> - %s</li>',
+      get_edit_post_link($post->ID),
+      get_the_title($post->ID),
+      get_the_author_meta('nicename', $post->post_author)
+    );
   }
 
   echo '</ul>';
@@ -362,11 +362,11 @@ function do_dashboard_widget() {
 // -- Helpers
 
 function user_can_revisionize() {
-  return apply_filters( 'revisionize_user_can_revisionize', current_user_can('edit_posts') );
+  return apply_filters('revisionize_user_can_revisionize', current_user_can('edit_posts'));
 }
 
 function user_can_publish_revision() {
-    return apply_filters( 'revisionize_user_can_publish_revision', current_user_can('publish_posts') || current_user_can('publish_pages') );
+  return apply_filters('revisionize_user_can_publish_revision', current_user_can('publish_posts') || current_user_can('publish_pages'));
 }
 
 function keep_original_on_publish() {
@@ -396,6 +396,10 @@ function is_revision_post($post) {
 
 function is_acf_post() {
   return has_action('acf/save_post') && (!empty($_POST['acf']) || !empty($_POST['fields']));
+}
+
+function show_dashboard_widget() {
+  return apply_filters('revisionize_show_dashboard_widget', false);
 }
 
 function get_revision_of($post) {

--- a/revisionize.php
+++ b/revisionize.php
@@ -140,6 +140,8 @@ function publish($post, $original) {
 
     wp_delete_post($post->ID, true);                                        // delete the variation
 
+    do_action('revision_published', $original->ID);   // after a revision was published
+
     if (!is_ajax() && !is_cron()) {
       wp_redirect(admin_url('post.php?action=edit&post=' . $original->ID));   // take us back to the live post
       exit;

--- a/revisionize.php
+++ b/revisionize.php
@@ -140,6 +140,8 @@ function publish($post, $original) {
 
     wp_delete_post($post->ID, true);                                        // delete the variation
 
+    do_action('revision_published', $original->ID);                         // after a revision was published
+
     if (!is_ajax() && !is_cron()) {
       wp_redirect(admin_url('post.php?action=edit&post=' . $original->ID));   // take us back to the live post
       exit;

--- a/revisionize.php
+++ b/revisionize.php
@@ -202,7 +202,7 @@ function copy_post($post, $to=null, $parent_id=null, $status='draft') {
     $new_id = $to->ID;
 
     // maintain original date. Fixes scheduled revisions overwriting the date. see issue #9
-    if (apply_filters('revisionize_preserve_post_date', true, $to->ID) === true)) {
+    if (apply_filters('revisionize_preserve_post_date', true, $to->ID) === true) {
       $data['post_date'] = $to->post_date;
       $data['post_date_gmt'] = get_gmt_from_date($post->post_date);
     }


### PR DESCRIPTION
This adds a "after" publish hooks to give third-parties the ability to hook in to the publish cycle of revisionize and run additional actions when a revision was published.