### PR TITLE
Add 'revisionize_copy_post_finish' action

### DIFF
--- a/revisionize.php
+++ b/revisionize.php
@@ -251,7 +251,7 @@ function copy_post($post, $to=null, $parent_id=null, $status='draft') {
   copy_post_meta_info($new_id, $post);
 
   // Let others know a copy has been made
-  do_action( 'revisionize_copy_post_finish', $new_id, $post );
+  do_action('revisionize_after_copy_post', $new_id, $post);
  
   return $new_id;
 }

--- a/revisionize.php
+++ b/revisionize.php
@@ -250,6 +250,9 @@ function copy_post($post, $to=null, $parent_id=null, $status='draft') {
   // apply revisionized post_meta to the original post.
   copy_post_meta_info($new_id, $post);
 
+  // Let others know a copy has been made
+  do_action( 'revisionize_copy_post_finish', $new_id, $post );
+ 
   return $new_id;
 }
 


### PR DESCRIPTION
When a post is copied, this allows for custom integration with plugins like WPML that need language info added to the new post. Otherwise, when WPML is enabled and an integration isn't made after the post is copied the post goes missing from admin page/posts lists.

After this hook is added, an example WPML integration might be something like this:
```
/**
 * ACTION :: Revisionize Copy Post 
 * Add WPML Lang Info for Revision
 *
 * @see   revisionize/revisionize.php :: copy_post()
 * @param [int]            $new_id - The new id of the revision created.
 * @param [WP_Post|object] $original_post - Post the revision was based on.
 * ------------------------------------------------------------------------- */
function revisionize_add_wpml_support_for_revision( $new_id, $original_post ) {
  global $sitepress;
  $post_lang = apply_filters( 'wpml_post_language_details', [ 'language_code' => 'en' ], $original_post->ID );
  $post_trid = $sitepress->get_element_trid( $new_id );
  $added     = $sitepress->set_element_language_details( $new_id, 'post_' . $original_post->post_type, $post_trid, $post_lang[ 'language_code' ], null, false );
}
add_action( 'revisionize_copy_post_finish', 'revisionize_add_wpml_support_for_revision', 10, 2 );
```