### PR TITLE
fix a php notice on the admin menu editor screen

### DIFF
--- a/revisionize.php
+++ b/revisionize.php
@@ -39,7 +39,7 @@ add_action('init', __NAMESPACE__.'\\init');
 function init() {
   // Only add filters and actions for admin who can actually edit posts
   if (is_admin() && user_can_revisionize() && is_post_type_enabled()) {
-    add_filter('display_post_states', __NAMESPACE__.'\\post_status_label');
+    add_filter('display_post_states', __NAMESPACE__.'\\post_status_label', 10, 2);
     add_filter('post_row_actions', __NAMESPACE__.'\\admin_actions', 10, 2);
     add_filter('page_row_actions', __NAMESPACE__.'\\admin_actions', 10, 2);
 
@@ -345,9 +345,8 @@ function admin_actions($actions, $post) {
 }
 
 // Filter for display_post_states which is only added if user_can_revisionize
-function post_status_label($states) {
-  global $post;
-  if (get_revision_of($post)) {
+function post_status_label($states, $post) {
+  if (!empty($post) && get_revision_of($post)) {
     $label = is_original_post($post) ? __('Backup Revision', 'revisionize') : __('Revision', 'revisionize');
     $label = apply_filters('revisionize_post_status_label', $label);
     array_unshift($states, $label);


### PR DESCRIPTION
There is a php warning on the menu editor in the pages meta box:

![image](https://user-images.githubusercontent.com/1686106/77450522-9a61e500-6db0-11ea-9a02-8e439c0699fd.png)

Diagnosing the issue it appears that the `Revisionize\post_status_label` function is relying on the global $post instead of the $post variable passed to the `display_post_states` filter, and not checking if the `$post` variable is empty before using it. The global $post variable does not exist on the menu editor and the menu editor is displaying post states on pages but passing an empty object to the get_post_states function.

This PR simply makes the check.