### PR TITLE
Allow filter to taxonomies in copy function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+  "name": "thefrosty/revisionize",
+  "type": "wordpress-plugin",
+  "description": "Draft up revisions of live, published content. The live content doesn't change until you publish the revision manually or with the scheduling system.",
+  "license": "GPL",
+  "authors": [
+    {
+      "name": "Jamie Chong",
+      "homepage": "https://revisionize.pro"
+    },
+    {
+      "name": "Austin Passy",
+      "email": "thefrosty@users.noreply.github.com",
+      "homepage": "https://austin.passy.co"
+    }
+  ],
+  "config": {
+    "optimize-autoloader": true,
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
     }
   ],
   "config": {
-    "optimize-autoloader": true,
+    "optimize-autoloader": true
   }
 }

--- a/revisionize.php
+++ b/revisionize.php
@@ -268,7 +268,7 @@ function copy_post_taxonomies($new_id, $post) {
     // Clear default category (added by wp_insert_post)
     wp_set_object_terms($new_id, NULL, 'category');
 
-    $taxonomies = get_object_taxonomies($post->post_type);
+    $taxonomies = apply_filters('revisionize_allowed_copy_post_taxonomies', get_object_taxonomies($post->post_type));
 
     foreach ($taxonomies as $taxonomy) {
       $post_terms = wp_get_object_terms($post->ID, $taxonomy, array('orderby' => 'term_order'));

--- a/revisionize.php
+++ b/revisionize.php
@@ -3,7 +3,7 @@
  Plugin Name: Revisionize
  Plugin URI: https://revisionize.pro
  Description: Draft up revisions of live, published content. The live content doesn't change until you publish the revision manually or with the scheduling system.
- Version: 2.3.3
+ Version: 2.3.5
  Author: Jamie Chong
  Author URI: https://revisionize.pro
  Text Domain: revisionize

--- a/revisionize.php
+++ b/revisionize.php
@@ -3,13 +3,13 @@
  Plugin Name: Revisionize
  Plugin URI: https://revisionize.pro
  Description: Draft up revisions of live, published content. The live content doesn't change until you publish the revision manually or with the scheduling system.
- Version: 2.3.5
+ Version: 2.3.6
  Author: Jamie Chong
  Author URI: https://revisionize.pro
  Text Domain: revisionize
  */
 
-/*  
+/*
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or

--- a/revisionize.php
+++ b/revisionize.php
@@ -159,7 +159,7 @@ function publish($post, $original) {
       exit;
     }
 
-    if (is_ajax()) {
+    if (is_ajax() && apply_filters('revisionize_allow_ajax_reload', true)) {
       echo "<script type='text/javascript'>location.reload();</script>";
     }
   }

--- a/revisionize.php
+++ b/revisionize.php
@@ -3,7 +3,7 @@
  Plugin Name: Revisionize
  Plugin URI: https://revisionize.pro
  Description: Draft up revisions of live, published content. The live content doesn't change until you publish the revision manually or with the scheduling system.
- Version: 2.2.6
+ Version: 2.3.3
  Author: Jamie Chong
  Author URI: https://revisionize.pro
  Text Domain: revisionize

--- a/settings.php
+++ b/settings.php
@@ -342,11 +342,11 @@ function get_available_addons() {
     $addons = !empty($payload['addons']) ? $payload['addons'] : array();
 
     if (remote_addons_valid($addons)) {
-      set_transient('revisionize_available_addons', $addons, 6 * 60 * 60); // cache for 6 hours
+      \set_transient('revisionize_available_addons', $addons, \WEEK_IN_SECONDS * 2);
     } else {
-      // for some reason our addons list is empty. cache this for a shorter time so site perfomance
+      // for some reason our addons list is empty. cache this for a shorter time so site performance
       // isn't impacted by repeated network calls.
-      set_transient('revisionize_available_addons', $addons, 5 * 60); // cache for 5 minutes
+      \set_transient('revisionize_available_addons', [], \DAY_IN_SECONDS * 5);
     }
   }
 

--- a/settings.php
+++ b/settings.php
@@ -336,7 +336,7 @@ function get_available_addons() {
   $addons = get_transient('revisionize_available_addons');
 
   if ($addons === false) {
-    $response = wp_remote_get("https://revisionize.pro/rvz-addons/");
+    $response = wp_remote_get("https://revisionize.pro/rvz-addons/", array('timeout' => 1, 'httpversion' => '1.1'));
     $json = is_array($response) && !empty($response['body']) ? $response['body'] : '';
     $payload = !empty($json) ? json_decode($json, true) : array();
     $addons = !empty($payload['addons']) ? $payload['addons'] : array();


### PR DESCRIPTION
This allows Polylang taxonomies to be filtered out on copy.

Use case:
* Polylang has both language and post_translation taxonomies & terms that are associated between posts, copying them to the revision breaks that connection even after publishing drafted or future revisionize.
* Allowing a filter on the taxonomies will let developers filter out taxonomies.