### PR TITLE
Check if get_parent_post exists as it may throw a fatal error on WP 5.7

### DIFF
--- a/revisionize.php
+++ b/revisionize.php
@@ -493,9 +493,11 @@ function get_parent_permalink($parent) {
   return sprintf('<a href="%s" target="_blank">%s</a>', get_permalink($parent->ID), $parent->post_title);
 }
 
-function get_parent_post($post) {
-  $id = $post ? get_revision_of($post) : false;
-  return $id ? get_post($id) : false;
+if ( ! function_exists( 'get_parent_post' ) ) {
+  function get_parent_post($post) {
+    $id = $post ? get_revision_of($post) : false;
+    return $id ? get_post($id) : false;
+  }
 }
 
 function get_current_post_type() {


### PR DESCRIPTION
Hi,

WordPress 5.7 will introduce a `get_parent_post()` function in WP Core.
It appears that this plugin is the only one in the WordPress plugin repository to use in. 
This pull request adds a `function_exists` check to avoid fatal errors.

For reference, see https://core.trac.wordpress.org/ticket/33045#comment:42

Thank you,
Jb